### PR TITLE
Checks for missing description

### DIFF
--- a/src/main/kotlin/com/redlimerl/mcsrlauncher/instance/mod/FabricModJson.kt
+++ b/src/main/kotlin/com/redlimerl/mcsrlauncher/instance/mod/FabricModJson.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 data class FabricModJson(
     val id: String,
     val name: String,
-    val description: String,
+    val description: String? = null,
     val version: String,
     val icon: String? = null
 )


### PR DESCRIPTION
Fixes #29 (hopefully)

I was originally just going to add a description to ZBufferFog's fabric.mod.json, but this seems better in the case of more mods lacking descriptions.