### PR TITLE
Fix opening URIs on Linux

### DIFF
--- a/src/main/kotlin/com/redlimerl/mcsrlauncher/gui/AccountListGui.kt
+++ b/src/main/kotlin/com/redlimerl/mcsrlauncher/gui/AccountListGui.kt
@@ -10,9 +10,9 @@ import com.redlimerl.mcsrlauncher.gui.component.AccountListComponent
 import com.redlimerl.mcsrlauncher.launcher.AccountManager
 import com.redlimerl.mcsrlauncher.util.I18n
 import com.redlimerl.mcsrlauncher.util.LauncherWorker
+import com.redlimerl.mcsrlauncher.util.OSUtils
 import com.redlimerl.mcsrlauncher.util.SwingUtils
 import java.awt.BorderLayout
-import java.awt.Desktop
 import java.awt.Dimension
 import java.awt.Toolkit
 import java.awt.datatransfer.StringSelection
@@ -53,7 +53,7 @@ class AccountListGui(parent: JFrame) : AccountListDialog() {
 
                 openPageButton.addActionListener {
                     Toolkit.getDefaultToolkit().systemClipboard.setContents(StringSelection(deviceCode.userCode), null)
-                    Desktop.getDesktop().browse(URI.create(deviceCode.verificationUrl))
+                    OSUtils.openURI(URI.create(deviceCode.verificationUrl))
                 }
                 cancelButton.addActionListener { this.dialog.dispose() }
 

--- a/src/main/kotlin/com/redlimerl/mcsrlauncher/gui/LogSubmitGui.kt
+++ b/src/main/kotlin/com/redlimerl/mcsrlauncher/gui/LogSubmitGui.kt
@@ -5,7 +5,7 @@ import com.redlimerl.mcsrlauncher.gui.component.AnalysisEditorPane
 import com.redlimerl.mcsrlauncher.util.AnalysisUtils.analyzeLog
 import com.redlimerl.mcsrlauncher.util.I18n
 import com.redlimerl.mcsrlauncher.util.LauncherWorker
-import java.awt.Desktop
+import com.redlimerl.mcsrlauncher.util.OSUtils
 import java.awt.Dimension
 import java.awt.Toolkit
 import java.awt.Window
@@ -26,7 +26,7 @@ class LogSubmitGui(window: Window) : LogSubmitDialog(window) {
         openButton.addActionListener {
             targetUrl?.let {
                 Toolkit.getDefaultToolkit().systemClipboard.setContents(StringSelection(it), null)
-                Desktop.getDesktop().browse(URI.create(it))
+                OSUtils.openURI(URI.create(it))
             }
         }
 

--- a/src/main/kotlin/com/redlimerl/mcsrlauncher/gui/MainMenuGui.kt
+++ b/src/main/kotlin/com/redlimerl/mcsrlauncher/gui/MainMenuGui.kt
@@ -9,6 +9,7 @@ import com.redlimerl.mcsrlauncher.launcher.AccountManager
 import com.redlimerl.mcsrlauncher.launcher.InstanceManager
 import com.redlimerl.mcsrlauncher.util.I18n
 import com.redlimerl.mcsrlauncher.util.LauncherWorker
+import com.redlimerl.mcsrlauncher.util.OSUtils
 import com.redlimerl.mcsrlauncher.util.SwingUtils
 import net.miginfocom.swing.MigLayout
 import java.awt.*
@@ -78,17 +79,17 @@ class MainMenuGui : MainForm() {
 
         initHeaderButton(discordButton)
         discordButton.addActionListener {
-            Desktop.getDesktop().browse(URI.create("https://mcsrlauncher.github.io/discord"))
+            OSUtils.openURI(URI.create("https://mcsrlauncher.github.io/discord"))
         }
 
         initHeaderButton(patreonButton)
         patreonButton.addActionListener {
-            Desktop.getDesktop().browse(URI.create("https://mcsrlauncher.github.io/patreon"))
+            OSUtils.openURI(URI.create("https://mcsrlauncher.github.io/patreon"))
         }
 
         initHeaderButton(githubButton)
         githubButton.addActionListener {
-            Desktop.getDesktop().browse(URI.create("https://github.com/MCSRLauncher/Launcher"))
+            OSUtils.openURI(URI.create("https://github.com/MCSRLauncher/Launcher"))
         }
     }
 

--- a/src/main/kotlin/com/redlimerl/mcsrlauncher/gui/MapBrowserGui.kt
+++ b/src/main/kotlin/com/redlimerl/mcsrlauncher/gui/MapBrowserGui.kt
@@ -4,6 +4,7 @@ import com.redlimerl.mcsrlauncher.data.instance.BasicInstance
 import com.redlimerl.mcsrlauncher.data.meta.map.MinecraftMapMeta
 import com.redlimerl.mcsrlauncher.util.I18n
 import com.redlimerl.mcsrlauncher.util.LauncherWorker
+import com.redlimerl.mcsrlauncher.util.OSUtils
 import com.redlimerl.mcsrlauncher.util.SwingUtils
 import java.awt.*
 import java.net.URI
@@ -61,7 +62,7 @@ class MapBrowserGui(window: Window, title: String, maps: List<MinecraftMapMeta>,
             if (map.sources != null) {
                 val sourceButton = JButton("Source")
                 sourceButton.addActionListener {
-                    Desktop.getDesktop().browse(URI.create(map.sources))
+                    OSUtils.openURI(URI.create(map.sources))
                 }
                 buttonPanel.add(sourceButton)
             }

--- a/src/main/kotlin/com/redlimerl/mcsrlauncher/gui/component/AnalysisEditorPane.kt
+++ b/src/main/kotlin/com/redlimerl/mcsrlauncher/gui/component/AnalysisEditorPane.kt
@@ -1,7 +1,7 @@
 package com.redlimerl.mcsrlauncher.gui.component
 
 import com.redlimerl.mcsrlauncher.MCSRLauncher
-import java.awt.Desktop
+import com.redlimerl.mcsrlauncher.util.OSUtils
 import java.net.URI
 import javax.swing.JEditorPane
 import javax.swing.event.HyperlinkEvent
@@ -13,7 +13,7 @@ object AnalysisEditorPane {
         editorPane.addHyperlinkListener {
             if (it.eventType == HyperlinkEvent.EventType.ACTIVATED) {
                 try {
-                    Desktop.getDesktop().browse(URI(it.url.toString()))
+                    OSUtils.openURI(URI(it.url.toString()))
                 } catch (ex: Exception) {
                     MCSRLauncher.LOGGER.error("Failed to open: ${it.url}", ex)
                 }

--- a/src/main/kotlin/com/redlimerl/mcsrlauncher/gui/component/GameVersionsPanel.kt
+++ b/src/main/kotlin/com/redlimerl/mcsrlauncher/gui/component/GameVersionsPanel.kt
@@ -13,11 +13,11 @@ import com.redlimerl.mcsrlauncher.gui.components.AbstractGameVersionsPanel
 import com.redlimerl.mcsrlauncher.launcher.MetaManager
 import com.redlimerl.mcsrlauncher.util.I18n
 import com.redlimerl.mcsrlauncher.util.LauncherWorker
+import com.redlimerl.mcsrlauncher.util.OSUtils
 import com.redlimerl.mcsrlauncher.util.SpeedrunUtils
 import com.redlimerl.mcsrlauncher.util.SwingUtils
 import io.github.z4kn4fein.semver.toVersion
 import java.awt.BorderLayout
-import java.awt.Desktop
 import java.net.URI
 import javax.swing.*
 import javax.swing.event.DocumentEvent
@@ -297,7 +297,7 @@ class GameVersionsPanel(private val parentWindow: JDialog, val instance: BasicIn
 
     private fun initMCSRRankedComponents() {
         mcsrRankedHelpButton.addActionListener {
-            Desktop.getDesktop().browse(URI.create("https://mcsrranked.com/"))
+            OSUtils.openURI(URI.create("https://mcsrranked.com/"))
         }
 
         MCSRRankedPackType.entries.forEach {

--- a/src/main/kotlin/com/redlimerl/mcsrlauncher/util/OSUtils.kt
+++ b/src/main/kotlin/com/redlimerl/mcsrlauncher/util/OSUtils.kt
@@ -2,7 +2,9 @@ package com.redlimerl.mcsrlauncher.util
 
 import com.redlimerl.mcsrlauncher.data.device.DeviceOSType
 import oshi.SystemInfo
+import java.awt.Desktop
 import java.io.File
+import java.net.URI
 
 object OSUtils {
 
@@ -34,6 +36,14 @@ object OSUtils {
 
     fun getTotalMemoryGB(): Double {
         return systemInfo.hardware.memory.total / (1024.0 * 1024 * 1024)
+    }
+
+    fun openURI(uri: URI) {
+        if (getOSType() == DeviceOSType.LINUX) {
+            Runtime.getRuntime().exec(arrayOf("xdg-open", uri.toString()))
+        } else {
+            Desktop.getDesktop().browse(uri)
+        }
     }
 
 }


### PR DESCRIPTION
`java.awt.Desktop` is not implemented well on Linux, [depending on Gnome libraries](https://docs.oracle.com/javase/tutorial/uiswing/misc/desktop.html), which makes links not work on any distribution where they aren't installed (most non gnome distros?). This PR uses freedesktop's [xdg-open](https://www.freedesktop.org/wiki/Software/xdg-utils/) instead, which should work on any XDG compliant distro. Other platforms are left untouched.