### PR TITLE
Sort Toolscreen meta versions by semver

### DIFF
--- a/src/main/kotlin/com/redlimerl/mcsrlauncher/data/instance/BasicInstance.kt
+++ b/src/main/kotlin/com/redlimerl/mcsrlauncher/data/instance/BasicInstance.kt
@@ -193,7 +193,7 @@ data class BasicInstance(
             val toolscreenFile = getToolscreenFile()
             if (toolscreenMeta != null && toolscreenFile != null && toolscreenMeta.tool.shouldApply()) {
                 for (version in toolscreenMeta.tool.versions.filter { it.version.startsWith("v") }
-                    .sortedByDescending { Version.parse(it.version.removePrefix("v")) }) {
+                    .sortedByDescending { Version.parse(it.version, false) }) {
                     if (version.name == options.selectToolscreenVersion || (options.autoToolscreenUpdates && !version.prerelease)) {
                         if (!toolscreenFile.exists() || !AssetUtils.compareHash(toolscreenFile, version.checksum.hash, AssetUtils.getHashFunction(version.checksum.type))) {
                             worker.setState("Downloading ${version.name}...")

--- a/src/main/kotlin/com/redlimerl/mcsrlauncher/data/instance/BasicInstance.kt
+++ b/src/main/kotlin/com/redlimerl/mcsrlauncher/data/instance/BasicInstance.kt
@@ -26,6 +26,7 @@ import com.redlimerl.mcsrlauncher.launcher.InstanceManager
 import com.redlimerl.mcsrlauncher.launcher.MetaManager
 import com.redlimerl.mcsrlauncher.network.FileDownloader
 import com.redlimerl.mcsrlauncher.util.*
+import io.github.z4kn4fein.semver.Version
 import io.github.z4kn4fein.semver.toVersionOrNull
 import kotlinx.coroutines.*
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -191,7 +192,8 @@ data class BasicInstance(
             val toolscreenMeta = MetaManager.getVersionMeta<SpeedrunToolsMetaFile>(MetaUniqueID.SPEEDRUN_TOOLS, "toolscreen", worker)
             val toolscreenFile = getToolscreenFile()
             if (toolscreenMeta != null && toolscreenFile != null && toolscreenMeta.tool.shouldApply()) {
-                for (version in toolscreenMeta.tool.versions) {
+                for (version in toolscreenMeta.tool.versions.filter { it.version.startsWith("v") }
+                    .sortedByDescending { Version.parse(it.version.removePrefix("v")) }) {
                     if (version.name == options.selectToolscreenVersion || (options.autoToolscreenUpdates && !version.prerelease)) {
                         if (!toolscreenFile.exists() || !AssetUtils.compareHash(toolscreenFile, version.checksum.hash, AssetUtils.getHashFunction(version.checksum.type))) {
                             worker.setState("Downloading ${version.name}...")

--- a/src/main/kotlin/com/redlimerl/mcsrlauncher/gui/InstanceOptionGui.kt
+++ b/src/main/kotlin/com/redlimerl/mcsrlauncher/gui/InstanceOptionGui.kt
@@ -15,6 +15,7 @@ import com.redlimerl.mcsrlauncher.instance.mod.ModData
 import com.redlimerl.mcsrlauncher.launcher.InstanceManager
 import com.redlimerl.mcsrlauncher.launcher.MetaManager
 import com.redlimerl.mcsrlauncher.util.*
+import io.github.z4kn4fein.semver.Version
 import org.apache.commons.io.FileUtils
 import java.awt.*
 import java.awt.datatransfer.DataFlavor
@@ -418,7 +419,8 @@ class InstanceOptionGui(parent: Window, private val instance: BasicInstance) : I
                         }
 
                         var targetVersion: SpeedrunToolVersion? = null
-                        for (version in toolscreenMeta.tool.versions) {
+                        for (version in toolscreenMeta.tool.versions.filter { it.version.startsWith("v") }
+                            .sortedByDescending { Version.parse(it.version, false) }) {
                             if (version.version == toolscreenVersionCombo.selectedItem?.toString()?.split(" (")?.first() || (instance.options.autoToolscreenUpdates && !version.prerelease)) {
                                 instance.options.selectToolscreenVersion = version.name
                                 targetVersion = version

--- a/src/main/kotlin/com/redlimerl/mcsrlauncher/instance/InstanceProcess.kt
+++ b/src/main/kotlin/com/redlimerl/mcsrlauncher/instance/InstanceProcess.kt
@@ -14,6 +14,7 @@ import com.redlimerl.mcsrlauncher.launcher.MetaManager
 import com.redlimerl.mcsrlauncher.util.AssetUtils
 import com.redlimerl.mcsrlauncher.util.I18n
 import com.redlimerl.mcsrlauncher.util.LauncherWorker
+import io.github.z4kn4fein.semver.Version
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import org.apache.commons.io.FileUtils
@@ -238,7 +239,8 @@ class InstanceProcess(val instance: BasicInstance) {
             val toolscreenMeta = MetaManager.getVersionMeta<SpeedrunToolsMetaFile>(MetaUniqueID.SPEEDRUN_TOOLS, "toolscreen", worker)
             val toolscreenFile = instance.getToolscreenFile()
             if (toolscreenMeta != null && toolscreenFile != null && toolscreenMeta.tool.shouldApply()) {
-                for (version in toolscreenMeta.tool.versions) {
+                for (version in toolscreenMeta.tool.versions.filter { it.version.startsWith("v") }
+                    .sortedByDescending { Version.parse(it.version, false) }) {
                     if (version.name == instance.options.selectToolscreenVersion) {
                         if (!toolscreenFile.exists() || !AssetUtils.compareHash(toolscreenFile, version.checksum.hash, AssetUtils.getHashFunction(version.checksum.type))) {
                             addLog("WARNING! INCORRECT HASH TOOLSCREEN HAS DETECTED! SKIPPED TO RUN\n\n")


### PR DESCRIPTION
should fix issue where an update to a previous release of toolscreen won't be considered the most up to date version by using semver sorting. (e.g., the change to 1.0.1's name was considered a new release so the launcher previously downloaded 1.0.1)