### PR TITLE
Fix rule evaluation

### DIFF
--- a/src/main/kotlin/com/redlimerl/mcsrlauncher/data/asset/game/GameLibrary.kt
+++ b/src/main/kotlin/com/redlimerl/mcsrlauncher/data/asset/game/GameLibrary.kt
@@ -3,6 +3,7 @@ package com.redlimerl.mcsrlauncher.data.asset.game
 import com.redlimerl.mcsrlauncher.MCSRLauncher
 import com.redlimerl.mcsrlauncher.data.asset.BasicAssetObject
 import com.redlimerl.mcsrlauncher.data.asset.rule.AssetRule
+import com.redlimerl.mcsrlauncher.data.asset.rule.evaluate
 import com.redlimerl.mcsrlauncher.data.device.DeviceArchitectureType
 import com.redlimerl.mcsrlauncher.data.device.RuntimeOSType
 import com.redlimerl.mcsrlauncher.instance.InstanceLibrary
@@ -65,12 +66,7 @@ data class GameLibrary(
         return list
     }
 
-    fun shouldApply(): Boolean {
-        for (rule in this.rules) {
-            if (!rule.shouldAllow()) return false
-        }
-        return true
-    }
+    fun shouldApply(): Boolean = rules.evaluate()
 
     fun toInstanceLibrary(): InstanceLibrary {
         return InstanceLibrary(

--- a/src/main/kotlin/com/redlimerl/mcsrlauncher/data/asset/rule/AssetRule.kt
+++ b/src/main/kotlin/com/redlimerl/mcsrlauncher/data/asset/rule/AssetRule.kt
@@ -8,12 +8,19 @@ data class AssetRule(
     val os: AssetRuleOS? = null,
     val features: AssetRuleFeatures? = null
 ) {
-
-    fun shouldAllow(): Boolean {
-        var applied = true
-        if (this.os != null && !this.os.apply()) applied = false
-
-        return this.action == AssetRuleAction.ALLOW == applied
+    fun applies(): Boolean {
+        if (this.os != null && !this.os.apply()) return false
+        return true
     }
+}
 
+fun List<AssetRule>.evaluate(): Boolean {
+    if (isEmpty()) return true
+    var allowed = false
+    for (rule in this) {
+        if (rule.applies()) {
+            allowed = rule.action == AssetRuleAction.ALLOW
+        }
+    }
+    return allowed
 }

--- a/src/main/kotlin/com/redlimerl/mcsrlauncher/data/meta/program/SpeedrunProgramMeta.kt
+++ b/src/main/kotlin/com/redlimerl/mcsrlauncher/data/meta/program/SpeedrunProgramMeta.kt
@@ -1,6 +1,7 @@
 package com.redlimerl.mcsrlauncher.data.meta.program
 
 import com.redlimerl.mcsrlauncher.data.asset.rule.AssetRule
+import com.redlimerl.mcsrlauncher.data.asset.rule.evaluate
 import com.redlimerl.mcsrlauncher.util.OSUtils
 import kotlinx.serialization.Serializable
 import java.net.URI
@@ -20,11 +21,6 @@ data class SpeedrunProgramMeta(
         OSUtils.openURI(URI.create(this.downloadPage))
     }
 
-    fun shouldApply(): Boolean {
-        for (rule in this.rules) {
-            if (!rule.shouldAllow()) return false
-        }
-        return true
-    }
+    fun shouldApply(): Boolean = rules.evaluate()
 
 }

--- a/src/main/kotlin/com/redlimerl/mcsrlauncher/data/meta/tool/SpeedrunToolMeta.kt
+++ b/src/main/kotlin/com/redlimerl/mcsrlauncher/data/meta/tool/SpeedrunToolMeta.kt
@@ -1,6 +1,7 @@
 package com.redlimerl.mcsrlauncher.data.meta.tool
 
 import com.redlimerl.mcsrlauncher.data.asset.rule.AssetRule
+import com.redlimerl.mcsrlauncher.data.asset.rule.evaluate
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -12,10 +13,5 @@ data class SpeedrunToolMeta(
     val rules: List<AssetRule> = listOf(),
     val versions: List<SpeedrunToolVersion>
 ) {
-    fun shouldApply(): Boolean {
-        for (rule in this.rules) {
-            if (!rule.shouldAllow()) return false
-        }
-        return true
-    }
+    fun shouldApply(): Boolean = rules.evaluate()
 }


### PR DESCRIPTION
This changes rule handling to ordered, last matching rule semantics, matching [Prism Launcher](https://github.com/PrismLauncher/PrismLauncher/blob/f67a670bcfb54a632d27dfa9b963e42a895047ab/launcher/minecraft/Rule.cpp#L86) behavior. Fixes #80 

Needed for LWJGL substitute libraries such as macOS LWJGL 2