### PR TITLE
Default Java settings from launcher

### DIFF
--- a/src/main/kotlin/com/redlimerl/mcsrlauncher/data/instance/InstanceOptions.kt
+++ b/src/main/kotlin/com/redlimerl/mcsrlauncher/data/instance/InstanceOptions.kt
@@ -31,8 +31,8 @@ data class InstanceOptions(
 
     override var minMemory: Int = 1024,
     override var maxMemory: Int = if (OSUtils.getTotalMemoryGB() > 15) 4096 else 2048,
-    override var javaPath: String = "",
-    override var jvmArguments: String = "",
+    override var javaPath: String = MCSRLauncher.options.javaPath,
+    override var jvmArguments: String = MCSRLauncher.options.jvmArguments,
     override var maximumResolution: Boolean = false,
     override var resolutionWidth: Int = 854,
     override var resolutionHeight: Int = 480


### PR DESCRIPTION
New instance now get the launcher's java settings as their default java settings
made so people who want to only change maximum memory allocation don't struggle with java path error